### PR TITLE
Fix locking in websocket service

### DIFF
--- a/internal/app/services/websocket.go
+++ b/internal/app/services/websocket.go
@@ -37,21 +37,21 @@ func NewWebSocketService(
 }
 
 func (srv *WebSocketService) AddClient(ws *websocket.Conn) {
-	srv.mu.RLock()
-	defer srv.mu.RUnlock()
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
 	srv.wsClients[ws] = true
 }
 
 func (srv *WebSocketService) RemoveClient(ws *websocket.Conn) {
-	srv.mu.RLock()
-	defer srv.mu.RUnlock()
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
 	_ = ws.Close()
 	delete(srv.wsClients, ws)
 }
 
 func (srv *WebSocketService) clientLen() int {
-	srv.mu.Lock()
-	defer srv.mu.Unlock()
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
 
 	return len(srv.wsClients)
 }


### PR DESCRIPTION
## Summary
- change WebSocketService AddClient/RemoveClient to use exclusive lock
- use read lock for clientLen

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68472ec3bb8c8331b74701f375579e9a