### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/upgrader/security/code-scanning/5](https://github.com/LiquidCats/upgrader/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for pushing Docker images to the GitHub Container Registry.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
