### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/upgrader/security/code-scanning/1](https://github.com/LiquidCats/upgrader/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out code and running tests, it only requires `contents: read` permissions. This ensures that the workflow has the minimal permissions necessary to perform its tasks. The `permissions` block will be added at the root level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
